### PR TITLE
build.rs: use default system compiler

### DIFF
--- a/libisoalloc-sys/build.rs
+++ b/libisoalloc-sys/build.rs
@@ -17,7 +17,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=HOST");
     println!("cargo:rerun-if-env-changed=PROFILE");
 
-    build.compiler("clang");
     build.include("isoalloc/include");
     build.files([
         "isoalloc/src/iso_alloc.c",


### PR DESCRIPTION
IsoAlloc builds fine with GCC too afaict, however with the specific clang clause the build is going to fail on a system without clang installed with:

```
warning: libisoalloc-sys@0.2.8: Compiler family detection failed due to
error: ToolNotFound: Failed to find tool. Is `clang` installed?

error: failed to run custom build command for `libisoalloc-sys v0.2.8`
```

Dropping the clause gives the user the freedom to pick their choice of C compiler.